### PR TITLE
docs: fix simple typo, cylce -> cycle

### DIFF
--- a/codec/src/main/jni/webrtc/libwebrtc/webrtc/common_audio/signal_processing/include/signal_processing_library.h
+++ b/codec/src/main/jni/webrtc/libwebrtc/webrtc/common_audio/signal_processing/include/signal_processing_library.h
@@ -1358,7 +1358,7 @@ void WebRtcSpl_SynthesisQMF(const int16_t* low_band,
 //
 // Algorithm:
 //
-// An iterative 4 cylce/bit routine
+// An iterative 4 cycle/bit routine
 //
 // Input:
 //      - value     : Value to calculate sqrt of


### PR DESCRIPTION
There is a small typo in codec/src/main/jni/webrtc/libwebrtc/webrtc/common_audio/signal_processing/include/signal_processing_library.h.

Should read `cycle` rather than `cylce`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md